### PR TITLE
Add support for --recent/-r flag to filter recently modified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ repoctx . --include "*.cpp,*.h,*.py"
 # Exclude certain patterns
 repoctx . --exclude "test,build,node_modules"
 
+# Only package files modified in the last 7 days
+repoctx . --recent
+
 # Show help
 repoctx --help
 
@@ -109,6 +112,9 @@ repoctx src docs
 
 # Mix files and directories
 repoctx src README.md CMakeLists.txt --output project-overview.md
+
+# Combination of different flags
+repoctx ./src --recent --exclude "README.md" --output recently-updated-files.md
 ```
 
 # Command Line Options
@@ -119,7 +125,7 @@ repoctx src README.md CMakeLists.txt --output project-overview.md
 | `--output`, `-o`  | Output file path                   | `repoctx -o report.md`           |
 | `--include`       | Include file extensions            | `--include "*.cpp,*.h"`           |
 | `--exclude`       | Exclude file patterns               | `--exclude "test,build"`          |
-
+| `--recent`       | Show files modified in the last 7 days | `repoctx . -r`          |
 
 
 # Output Format 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <fstream>
 #include <sstream>
-
+#include <chrono>
 
 void setFiltering(const std::string& include, const std::string& exclude);
  bool excludedExtensions(const std::string& filepath, const std::string& excludedExtension);
@@ -19,3 +19,4 @@ void setFiltering(const std::string& include, const std::string& exclude);
  bool onlyIncludedExtensions(const std::string& extension,const std::string&includedFiles);
  bool isGitIgnored(const std::filesystem::path& filePath);
  bool matchingFileDir(const std::string& path, const std::string& filter);
+ bool isRecentlyModified(const std::filesystem::path& filePath, int days = 7); // new

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -35,6 +35,11 @@ namespace cli {
 			else if (argument == "--exclude" && i + 1 < argc) {
 				options.excludePattern = argv[++i];
 			}
+			
+			// new:
+			else if ((argument == "-r" || argument == "--recent") && i + 1 < argc) {
+				options.recent = true;
+			}
 
 			else {
 				options.inputFiles.push_back(argument);

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -9,6 +9,7 @@ namespace cli {
 	struct Options {
 		bool showHelp = false;
 		bool showVersion = false;
+		bool recent = false; // new
 		std::string outputFile;
 		std::vector<std::string_view>inputFiles; //for getting more than one file and  getting total inputs
 		std::string fileExtension;

--- a/src/renderer.hpp
+++ b/src/renderer.hpp
@@ -7,6 +7,7 @@
 #include "cli.hpp"
 #include "git_info.hpp"
 #include "fs_travel.hpp"
+#include "utils.hpp"
 
 namespace output {
 	//output target


### PR DESCRIPTION
Fixes #5

## Summary
This PR implements a new feature to filter files based on recent modifications using the --recent / -r command-line flag. When this flag is set, the tool will only include files that have been modified within the last 7 days in the output. This provides more relevant context for recent development work without including the entire repository history.

## Changes Made
- Added support for a new CLI flag `--recent` or `-r` in cli.cpp, so users can filter files based on modification time.
- Introduced a new utility function `isRecentlyModified(const std::filesystem::path& filePath, int days)` in `utils.cpp`/`utils.hpp`, which checks if a file was modified within the last N days (default = 7).
- The filtering logic was added into `checkingExcludeInclude()` in `utils.cpp` because that function already handled `--include` and `--exclude` checks, making it the natural integration point for another filter.
- Updated `fs_travel.cpp` file traversal logic to respect the `--recent` flag. If `--recent` is set, files are filtered through `isRecentlyModified()` in addition to include/exclude patterns.
- Updated the renderer to add a “Recent Changes” section in the output, showing only files modified in the last 7 days when the flag is used.

## Future Work
- The number of days (7) is currently hard-coded
- The “days ago” calculation is approximate, integer division of hours to days, and does not handle partial days (e.g., 23 hours ago is shown as 0 days ago).
- We can also include when each file was last modified (e.g., "Modified: src/main.js (2 days ago)") in the Recent Changes section.